### PR TITLE
change credits positioning css attribute

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -308,13 +308,13 @@
 
 .left-credits {
   position: absolute;
-  top: 95%;
+  bottom: 1%;
   right: 53%;
   color: #ffffff;
 }
 
 .right-credits {
   position: absolute;
-  top: 95%;
+  bottom: 1%;
   left: 53%;
 }


### PR DESCRIPTION
using botton instead of top for positioning the credits prevents the page showing a scroll bar in lower resolutions